### PR TITLE
Option fields in struct

### DIFF
--- a/src/de/field.rs
+++ b/src/de/field.rs
@@ -133,9 +133,9 @@ impl<'de> de::Deserializer<'de> for FieldDeserializer {
         V: de::Visitor<'de>,
     {
         if self.0.is_empty() {
-            visitor.visit_some(self)
-        } else {
             visitor.visit_none()
+        } else {
+            visitor.visit_some(self)
         }
     }
 

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -213,11 +213,12 @@ mod tests {
         requestdistribution: String,
 
         optional_string: Option<String>,
+        optional_string_empty: Option<String>,
         optional_usize: Option<usize>,
         optional_bool: Option<bool>,
-        optional_string_empty: Option<String>,
-        optional_usize_empty: Option<usize>,
-        optional_bool_empty: Option<bool>,
+        optional_string_not_set: Option<String>,
+        optional_usize_not_set: Option<usize>,
+        optional_bool_not_set: Option<bool>,
     }
 
     #[test]
@@ -237,6 +238,7 @@ insertproportion=0
 requestdistribution=zipfian
 
 optional_string=Hello, world!
+optional_string_empty=
 optional_usize=42
 optional_bool=true
 ";
@@ -259,11 +261,12 @@ optional_bool=true
                 requestdistribution: "zipfian".to_string(),
 
                 optional_string: Some("Hello, world!".to_string()),
+                optional_string_empty: None,
                 optional_usize: Some(42),
                 optional_bool: Some(true),
-                optional_string_empty: None,
-                optional_usize_empty: None,
-                optional_bool_empty: None
+                optional_string_not_set: None,
+                optional_usize_not_set: None,
+                optional_bool_not_set: None
             }
         );
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -211,6 +211,8 @@ mod tests {
         insertproportion: f32,
 
         requestdistribution: String,
+
+        quite: Option<String>,
     }
 
     #[test]
@@ -228,6 +230,8 @@ scanproportion=0
 insertproportion=0
 
 requestdistribution=zipfian
+
+quite=not
 ";
         let deserializer = Deserializer::from_str(data);
         let workload_a = Workload::deserialize(deserializer).unwrap();
@@ -246,6 +250,8 @@ requestdistribution=zipfian
                 insertproportion: 0.0,
 
                 requestdistribution: "zipfian".to_string(),
+
+                quite: Some("not".to_string())
             }
         );
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -212,7 +212,12 @@ mod tests {
 
         requestdistribution: String,
 
-        quite: Option<String>,
+        optional_string: Option<String>,
+        optional_usize: Option<usize>,
+        optional_bool: Option<bool>,
+        optional_string_empty: Option<String>,
+        optional_usize_empty: Option<usize>,
+        optional_bool_empty: Option<bool>,
     }
 
     #[test]
@@ -231,7 +236,9 @@ insertproportion=0
 
 requestdistribution=zipfian
 
-quite=not
+optional_string=Hello, world!
+optional_usize=42
+optional_bool=true
 ";
         let deserializer = Deserializer::from_str(data);
         let workload_a = Workload::deserialize(deserializer).unwrap();
@@ -251,7 +258,12 @@ quite=not
 
                 requestdistribution: "zipfian".to_string(),
 
-                quite: Some("not".to_string())
+                optional_string: Some("Hello, world!".to_string()),
+                optional_usize: Some(42),
+                optional_bool: Some(true),
+                optional_string_empty: None,
+                optional_usize_empty: None,
+                optional_bool_empty: None
             }
         );
     }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -213,9 +213,11 @@ mod tests {
         requestdistribution: String,
 
         optional_string: Option<String>,
-        optional_string_empty: Option<String>,
         optional_usize: Option<usize>,
         optional_bool: Option<bool>,
+        optional_string_empty: Option<String>,
+        optional_usize_empty: Option<usize>,
+        optional_bool_empty: Option<bool>,
         optional_string_not_set: Option<String>,
         optional_usize_not_set: Option<usize>,
         optional_bool_not_set: Option<bool>,
@@ -238,9 +240,11 @@ insertproportion=0
 requestdistribution=zipfian
 
 optional_string=Hello, world!
-optional_string_empty=
 optional_usize=42
 optional_bool=true
+optional_string_empty=
+optional_usize_empty=
+optional_bool_empty=
 ";
         let deserializer = Deserializer::from_str(data);
         let workload_a = Workload::deserialize(deserializer).unwrap();
@@ -261,9 +265,11 @@ optional_bool=true
                 requestdistribution: "zipfian".to_string(),
 
                 optional_string: Some("Hello, world!".to_string()),
-                optional_string_empty: None,
                 optional_usize: Some(42),
                 optional_bool: Some(true),
+                optional_string_empty: None,
+                optional_usize_empty: None,
+                optional_bool_empty: None,
                 optional_string_not_set: None,
                 optional_usize_not_set: None,
                 optional_bool_not_set: None


### PR DESCRIPTION
This PR should fix issues with `Option` fields in struct.
If struct has `Option` and field is empty, or missing, it should be `None`.
If struct has `Option` and field is set it should be `Some(value)`.